### PR TITLE
feat: クリップボードコピーを -c オプション指定時のみに変更

### DIFF
--- a/index.js
+++ b/index.js
@@ -361,9 +361,10 @@ AWS_SESSION_TOKEN=${credentials.sessionToken}`;
  * @param {string} roleArn - Role ARN to assume
  * @param {string} sourceProfile - Source profile to use for AssumeRole
  * @param {string} mfaCode - MFA authentication code (optional)
+ * @param {boolean} shouldCopy - Whether to copy credentials to clipboard
  * @returns {boolean} Success status
  */
-const performAssumeRoleWithArn = (roleArn, sourceProfile, mfaCode = null) => {
+const performAssumeRoleWithArn = (roleArn, sourceProfile, mfaCode = null, shouldCopy = false) => {
   try {
     // Get credentials (1Password priority with fallback)
     const baseCreds = getCredentials(sourceProfile);
@@ -433,17 +434,20 @@ export AWS_ASSUMED_ROLE_NAME=${roleName}`;
     fs.writeFileSync(CONFIG.credentialsFile, credentialsContent);
     
     // Copy to clipboard and display result
-    const clipboardSuccess = copyToClipboard(creds);
-    const message = clipboardSuccess 
-      ? `Successfully assumed role: ${roleName}`
-      : `Successfully assumed role: ${roleName} (clipboard copy failed)`;
-    
-    console.log(message);
-    
+    if (shouldCopy) {
+      const clipboardSuccess = copyToClipboard(creds);
+      const message = clipboardSuccess
+        ? `Successfully assumed role: ${roleName} (credentials copied to clipboard)`
+        : `Successfully assumed role: ${roleName} (clipboard copy failed)`;
+      console.log(message);
+    } else {
+      console.log(`Successfully assumed role: ${roleName}`);
+    }
+
     // Display current AWS identity for confirmation
     try {
       console.log('\nCurrent AWS identity:');
-      const callerIdentity = execSync('aws sts get-caller-identity --output table 2>/dev/null', { 
+      const callerIdentity = execSync('aws sts get-caller-identity --output table 2>/dev/null', {
         encoding: 'utf8',
         env: {
           ...process.env,
@@ -456,9 +460,9 @@ export AWS_ASSUMED_ROLE_NAME=${roleName}`;
     } catch (error) {
       // Silently ignore errors to avoid disrupting the main flow
     }
-    
+
     return true;
-    
+
   } catch (error) {
     console.error('Error assuming role:', error.message);
     return false;
@@ -469,9 +473,10 @@ export AWS_ASSUMED_ROLE_NAME=${roleName}`;
  * Perform AWS STS AssumeRole with MFA
  * @param {string} profile - AWS profile name
  * @param {string} mfaCode - MFA authentication code
+ * @param {boolean} shouldCopy - Whether to copy credentials to clipboard
  * @returns {boolean} Success status
  */
-const performAssumeRole = (profile, mfaCode) => {
+const performAssumeRole = (profile, mfaCode, shouldCopy = false) => {
   try {
     // Get credentials (1Password priority with fallback)
     const baseCreds = getCredentials(profile);
@@ -527,12 +532,15 @@ export AWS_DEFAULT_PROFILE=${profile}`;
     fs.writeFileSync(CONFIG.credentialsFile, credentialsContent);
     
     // Copy to clipboard and display result
-    const clipboardSuccess = copyToClipboard(creds);
-    const message = clipboardSuccess 
-      ? `Successfully assumed role for profile: ${profile}`
-      : `Successfully assumed role for profile: ${profile} (clipboard copy failed)`;
-    
-    console.log(message);
+    if (shouldCopy) {
+      const clipboardSuccess = copyToClipboard(creds);
+      const message = clipboardSuccess
+        ? `Successfully assumed role for profile: ${profile} (credentials copied to clipboard)`
+        : `Successfully assumed role for profile: ${profile} (clipboard copy failed)`;
+      console.log(message);
+    } else {
+      console.log(`Successfully assumed role for profile: ${profile}`);
+    }
     
     // Display current AWS identity for confirmation
     try {
@@ -564,8 +572,9 @@ export AWS_DEFAULT_PROFILE=${profile}`;
  */
 const main = async () => {
   try {
-    // Check if Role ARN is provided as command line argument
+    // Parse command line arguments
     const args = process.argv.slice(2);
+    const shouldCopyToClipboard = args.includes('-c');
     const roleArnArg = args.find(arg => isRoleArn(arg));
     
     if (roleArnArg) {
@@ -577,7 +586,7 @@ const main = async () => {
         // MFA is required
         try {
           const mfaCode = await getMfaCode();
-          const success = performAssumeRoleWithArn(roleArnArg, sourceProfile, mfaCode);
+          const success = performAssumeRoleWithArn(roleArnArg, sourceProfile, mfaCode, shouldCopyToClipboard);
 
           if (!success) {
             process.exit(1);
@@ -588,8 +597,8 @@ const main = async () => {
         }
       } else {
         // No MFA required
-        const success = performAssumeRoleWithArn(roleArnArg, sourceProfile);
-        
+        const success = performAssumeRoleWithArn(roleArnArg, sourceProfile, null, shouldCopyToClipboard);
+
         if (!success) {
           process.exit(1);
         }
@@ -613,7 +622,7 @@ const main = async () => {
     if (hasRoleConfiguration(profileChoice)) {
       try {
         const mfaCode = await getMfaCode();
-        const success = performAssumeRole(profileChoice, mfaCode);
+        const success = performAssumeRole(profileChoice, mfaCode, shouldCopyToClipboard);
 
         if (!success) {
           process.exit(1);

--- a/run.sh
+++ b/run.sh
@@ -24,6 +24,7 @@ check_dependencies() {
 assume_role_with_mfa() {
   local profile=$1
   local mfa_code=$2
+  local copy_flag=$3
   
   # Get required configuration from AWS config
   local role_arn=$(aws configure get $profile.role_arn 2>/dev/null)
@@ -52,17 +53,21 @@ assume_role_with_mfa() {
   AWS_SECRET_ACCESS_KEY=$(echo "$AWS_STS_CREDENTIALS" | jq -r '.Credentials.SecretAccessKey')
   AWS_SESSION_TOKEN=$(echo "$AWS_STS_CREDENTIALS" | jq -r '.Credentials.SessionToken')
   
-  # Copy credentials to clipboard
-  clipboard_content="AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+  # Copy credentials to clipboard (only with -c flag)
+  if [ "$copy_flag" = "true" ]; then
+    clipboard_content="AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 AWS_REGION=$AWS_REGION
 AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN"
-  
-  echo "$clipboard_content" | pbcopy 2>/dev/null
-  if [ $? -eq 0 ]; then
-    echo "Credentials copied to clipboard"
+
+    echo "$clipboard_content" | pbcopy 2>/dev/null
+    if [ $? -eq 0 ]; then
+      echo "Credentials copied to clipboard"
+    else
+      echo "Successfully assumed role (clipboard copy failed)"
+    fi
   else
-    echo "Successfully assumed role (clipboard copy failed)"
+    echo "Successfully assumed role"
   fi
 }
 
@@ -102,6 +107,7 @@ assume_role_with_arn() {
   local role_arn="$1"
   local source_profile="$2"
   local mfa_code="$3"
+  local copy_flag="$4"
   
   local session_name="awsp-$(date +%s)"
   local role_name="$(basename "$role_arn")"
@@ -132,25 +138,33 @@ assume_role_with_arn() {
   AWS_SECRET_ACCESS_KEY=$(echo "$AWS_STS_CREDENTIALS" | jq -r '.Credentials.SecretAccessKey')
   AWS_SESSION_TOKEN=$(echo "$AWS_STS_CREDENTIALS" | jq -r '.Credentials.SessionToken')
   
-  # Copy credentials to clipboard
-  clipboard_content="AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+  # Copy credentials to clipboard (only with -c flag)
+  if [ "$copy_flag" = "true" ]; then
+    clipboard_content="AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 AWS_REGION=$AWS_REGION
 AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN"
-  
-  echo "$clipboard_content" | pbcopy 2>/dev/null
-  if [ $? -eq 0 ]; then
-    echo "Successfully assumed role: $role_name (credentials copied to clipboard)"
+
+    echo "$clipboard_content" | pbcopy 2>/dev/null
+    if [ $? -eq 0 ]; then
+      echo "Successfully assumed role: $role_name (credentials copied to clipboard)"
+    else
+      echo "Successfully assumed role: $role_name (clipboard copy failed)"
+    fi
   else
-    echo "Successfully assumed role: $role_name (clipboard copy failed)"
+    echo "Successfully assumed role: $role_name"
   fi
 }
 
 # Parse command line options
 mfa_code=""
 source_profile=""
-while getopts "m:p:" opt; do
+copy_to_clipboard=""
+while getopts "cm:p:" opt; do
   case $opt in
+    c)
+      copy_to_clipboard="true"
+      ;;
     m)
       mfa_code="$OPTARG"
       ;;
@@ -158,16 +172,17 @@ while getopts "m:p:" opt; do
       source_profile="$OPTARG"
       ;;
     \?)
-      echo "Usage: $0 [-m MFA_CODE] [-p SOURCE_PROFILE] [PROFILE_NAME|ROLE_ARN]" >&2
+      echo "Usage: $0 [-c] [-m MFA_CODE] [-p SOURCE_PROFILE] [PROFILE_NAME|ROLE_ARN]" >&2
       echo "" >&2
       echo "Options:" >&2
+      echo "  -c                 Copy credentials to clipboard after assuming role" >&2
       echo "  -m MFA_CODE        MFA authentication code" >&2
       echo "  -p SOURCE_PROFILE  Source profile to use for AssumeRole (defaults to current AWS_PROFILE or default)" >&2
       echo "" >&2
       echo "Examples:" >&2
       echo "  $0 my-profile                                          # Switch to profile" >&2
-      echo "  $0 arn:aws:iam::123456789012:role/MyRole              # Assume role with ARN" >&2
-      echo "  $0 -m 123456 arn:aws:iam::123456789012:role/MyRole    # Assume role with MFA" >&2
+      echo "  $0 -c arn:aws:iam::123456789012:role/MyRole           # Assume role with ARN and copy to clipboard" >&2
+      echo "  $0 -c -m 123456 arn:aws:iam::123456789012:role/MyRole # Assume role with MFA and copy to clipboard" >&2
       echo "  $0 -p source-profile arn:aws:iam::123456789012:role/MyRole  # Assume role with specific source profile" >&2
       exit 1
       ;;
@@ -187,12 +202,12 @@ if [ $# -ge 1 ]; then
       source_profile="${AWS_PROFILE:-${AWS_DEFAULT_PROFILE:-default}}"
     fi
     
-    assume_role_with_arn "$argument" "$source_profile" "$mfa_code"
+    assume_role_with_arn "$argument" "$source_profile" "$mfa_code" "$copy_to_clipboard"
   else
     # Profile name provided
     if [ -n "$mfa_code" ]; then
       # MFA code provided: execute AssumeRole directly
-      assume_role_with_mfa "$argument" "$mfa_code"
+      assume_role_with_mfa "$argument" "$mfa_code" "$copy_to_clipboard"
     else
       # No MFA code: set profile conventionally
       export AWS_PROFILE="$argument"
@@ -203,7 +218,11 @@ if [ $# -ge 1 ]; then
 else
   # Interactive mode: run Node.js selector
   CURRENT=$(cd $(dirname $0);pwd)
-  "$CURRENT/index.js"
+  if [ "$copy_to_clipboard" = "true" ]; then
+    "$CURRENT/index.js" -c
+  else
+    "$CURRENT/index.js"
+  fi
 
   selected_profile="$(cat ~/.awsp 2>/dev/null)"
   


### PR DESCRIPTION
## Summary
- デフォルトではクレデンシャルのクリップボードコピーを無効化
- `-c` オプション指定時のみ `pbcopy` でクリップボードにコピーする動作に変更
- `run.sh` と `index.js` の両方で `-c` フラグをサポート

## 変更内容
### `run.sh`
- `getopts` に `-c` オプションを追加
- `assume_role_with_mfa()` / `assume_role_with_arn()` でコピーフラグによる条件分岐
- インタラクティブモード時に `-c` フラグを `index.js` へ引き渡し
- Usage メッセージに `-c` オプションの説明を追加

### `index.js`
- `process.argv` から `-c` フラグを検出
- `performAssumeRole()` / `performAssumeRoleWithArn()` に `shouldCopy` パラメータを追加
- クリップボードコピーと成功メッセージをフラグで条件分岐

## Test plan
- [ ] `awsp` でプロファイル切り替え → クリップボードにコピーされないことを確認
- [ ] `awsp -c` でプロファイル切り替え → クリップボードにコピーされることを確認
- [ ] `awsp -c -m 123456 arn:aws:...` → クリップボードにコピーされることを確認
- [ ] `awsp -m 123456 arn:aws:...` → クリップボードにコピーされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)